### PR TITLE
Add api key to eraser map

### DIFF
--- a/map/index.html
+++ b/map/index.html
@@ -13,6 +13,8 @@
     <script src="https://mapzen.com/js/mapzen.min.js"></script>
     <script>
 
+      L.Mapzen.apiKey = 'mapzen-qKhY2A';
+
       // when GeoIP is available, set the map's initial view to detected coords.
       var lat, lon;
 


### PR DESCRIPTION
Add api key to eraser map - required for new mapzen.js release.